### PR TITLE
fix: corrigindo erro de casensitve da variavel dbHost

### DIFF
--- a/config.php
+++ b/config.php
@@ -10,7 +10,7 @@ $dbUser = 'gabi';
 $dbPass = 'senha';
 
 try {
-    $conn = mysqli_connect($dbHOst, $dbUser, $dbPass, $dbName);   
+    $conn = mysqli_connect($dbHost, $dbUser, $dbPass, $dbName);
 } catch (\Throwable $th) {
     throw $th;
 }


### PR DESCRIPTION
Eu notei que no arquivo config.php estava ocorrendo um erro na execução do programa por conta de haver um erro de nomenclatura de variável, fiz a correção para você. 